### PR TITLE
docs: remove version from helm chart docs

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -1,7 +1,5 @@
 # cert-manager-webhook-hetzner
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square)
-
 cert-manager ACME webhook for Hetzner
 
 ## Values
@@ -26,4 +24,3 @@ cert-manager ACME webhook for Hetzner
 | service.port | int | `443` | Port of the webhooks service. |
 | service.type | string | `"ClusterIP"` | Kubernetes service type of the webhooks service. |
 | tolerations | list | `[]` | [Kubernetes tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration) for the webhook. |
-

--- a/chart/README.md.gotmpl
+++ b/chart/README.md.gotmpl
@@ -1,0 +1,14 @@
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}


### PR DESCRIPTION
This ensures the releaser-pleaser PR do not fail with pre-commit.