### PR TITLE
test: rework e2e test targets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,11 @@ jobs:
         run: |
           go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
+      - name: Setup tests
+        run: make e2e-setup
+
       - name: Run tests
-        run: make test-coverage
+        run: make e2e-coverage
 
       - name: upload coverage reports to codecov
         if: >

--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,15 @@ TESTDATA = testdata/env testdata/hetzner/secret.yaml
 test:
 	go test -v ./...
 
+.PHONY: e2e-setup
+e2e-setup: $(TESTDATA)
+
 .PHONY: e2e
 e2e: $(TESTDATA)
 	source testdata/env; go test -v -tags e2e -timeout=30m ./...
 
-.PHONY: test-coverage
-test-coverage: $(TESTDATA)
+.PHONY: e2e-coverage
+e2e-coverage: $(TESTDATA)
 	source testdata/env; go test -v -tags e2e -timeout=30m -coverpkg=./... -coverprofile=coverage.txt -covermode count ./...
 
 .PHONY: helm-package

--- a/README.md
+++ b/README.md
@@ -65,9 +65,7 @@ else they will have undetermined behaviour when used with cert-manager.
 
 You can run the test suite by:
 
-1. Placing your base64 encoded hcloud API token in `testdata/hetzner/secret.yaml`
-2. Run the test suite:
-
 ```bash
-make test
+HETZNER_TOKEN="your-secret-token" make e2e-setup
+make e2e
 ```


### PR DESCRIPTION
- Split test setup and actual tests steps in CI.
- Rename some test target to reflect the actual test that are run.
- Update the e2e test documentation.