### PR TITLE
chore: remove unbound from development cluster

### DIFF
--- a/dev/variables.tf
+++ b/dev/variables.tf
@@ -11,3 +11,8 @@ variable "k3s_channel" {
   type    = string
   default = "stable"
 }
+
+variable "use_unbound" {
+  type    = bool
+  default = false
+}


### PR DESCRIPTION
The DNS API is live now, and we can use the Hetzner DNS servers for our development cluster.

Note: This cluster is not used in the e2e tests. It is purely for development and debugging customer issues.