### PR TITLE
feat: push image to hetzner docker namespace

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,7 +27,7 @@ kos:
   - id: container-image
     build: binary
     repositories:
-      - hetznercloud/cert-manager-webhook-hetzner
+      - hetzner/cert-manager-webhook-hetzner
     platforms:
       - linux/amd64
       - linux/arm64

--- a/chart/.snapshots/example.yaml
+++ b/chart/.snapshots/example.yaml
@@ -191,7 +191,7 @@ spec:
       serviceAccountName: snapshot-cert-manager-webhook-hetzner
       containers:
         - name: cert-manager-webhook-hetzner
-          image: "docker.io/hetznercloud/cert-manager-webhook-hetzner:v0.3.0" # x-releaser-pleaser-version
+          image: "docker.io/hetzner/cert-manager-webhook-hetzner:v0.3.0" # x-releaser-pleaser-version
           imagePullPolicy: IfNotPresent
           args:
             - --tls-cert-file=/tls/tls.crt

--- a/chart/README.md
+++ b/chart/README.md
@@ -14,7 +14,7 @@ cert-manager ACME webhook for Hetzner
 | fullnameOverride | string | `""` | Override the full name of the chart. |
 | groupName | string | `"acme.hetzner.com"` | The GroupName here is used to identify your company or business unit that created this webhook. For example, this may be "acme.mycompany.com". This name will need to be referenced in each Issuer's `webhook` stanza to inform cert-manager of where to send ChallengePayload resources in order to solve the DNS01 challenge. This group name should be **unique**, hence using your own company's domain here is recommended. |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy of the webhook image. |
-| image.repository | string | `"docker.io/hetznercloud/cert-manager-webhook-hetzner"` | Repository of the webhook image. |
+| image.repository | string | `"docker.io/hetzner/cert-manager-webhook-hetzner"` | Repository of the webhook image. |
 | image.tag | string | Current version | Tag of the webhook image. |
 | imagePullSecrets | list | `[]` | Additional image pull secrets in the [standard Kubernetes format](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) |
 | metrics.serviceMonitor.enabled | bool | `false` | Deploys a ServiceMonitor to scrape the metrics. **Requires** the ServiceMonitor CRD. |

--- a/chart/example-values.yaml
+++ b/chart/example-values.yaml
@@ -5,7 +5,7 @@ certManager:
   serviceAccountName: cert-manager
 
 image:
-  repository: docker.io/hetznercloud/cert-manager-webhook-hetzner
+  repository: docker.io/hetzner/cert-manager-webhook-hetzner
   tag: v0.3.0 # x-releaser-pleaser-version
   pullPolicy: IfNotPresent
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -23,7 +23,7 @@ imagePullSecrets: []
 
 image:
   # -- Repository of the webhook image.
-  repository: docker.io/hetznercloud/cert-manager-webhook-hetzner
+  repository: docker.io/hetzner/cert-manager-webhook-hetzner
   # -- Tag of the webhook image.
   # @default -- Current version
   tag: v0.3.0 # x-releaser-pleaser-version

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cert-manager-webhook-hetzner
 build:
   artifacts:
-    - image: docker.io/hetznercloud/cert-manager-webhook-hetzner
+    - image: docker.io/hetzner/cert-manager-webhook-hetzner
       ko: {}
   local:
     useBuildkit: true


### PR DESCRIPTION
We are moving our container image to [docker.io/hetzner/cert-manager-webhook-hetzner](https://hub.docker.com/r/hetzner/cert-manager-webhook-hetzner).