### PR TITLE
feat(helm): default to restricted security context

### DIFF
--- a/chart/.snapshots/example.yaml
+++ b/chart/.snapshots/example.yaml
@@ -189,7 +189,10 @@ spec:
     spec:
       securityContext:
         runAsGroup: 1000
+        runAsNonRoot: true
         runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: snapshot-cert-manager-webhook-hetzner
       containers:
         - name: cert-manager-webhook-hetzner
@@ -225,6 +228,9 @@ spec:
               readOnly: true
           securityContext:
             allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           resources:
             limits:
               cpu: 100m

--- a/chart/README.md
+++ b/chart/README.md
@@ -10,7 +10,7 @@ cert-manager ACME webhook for Hetzner
 | annotations | object | `{}` | [Kubernetes annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) added to the deployment metadata |
 | certManager.namespace | string | `"cert-manager"` | Namespace of your cert-manager deployment. |
 | certManager.serviceAccountName | string | `"cert-manager"` | Name of the cert-managers service account. |
-| containerSecurityContext | object | `{}` | [Kubernetes container security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) for the webhook. |
+| containerSecurityContext | object | [Restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted) | [Kubernetes container security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) for the webhook. |
 | env | object | `{}` | Additional environment variables, where each key represents the name of the variable. The value follows standard Kubernetes environment variable formats. |
 | fullnameOverride | string | `""` | Override the full name of the chart. |
 | groupName | string | `"acme.hetzner.com"` | The GroupName here is used to identify your company or business unit that created this webhook. For example, this may be "acme.mycompany.com". This name will need to be referenced in each Issuer's `webhook` stanza to inform cert-manager of where to send ChallengePayload resources in order to solve the DNS01 challenge. This group name should be **unique**, hence using your own company's domain here is recommended. |
@@ -23,7 +23,7 @@ cert-manager ACME webhook for Hetzner
 | nameOverride | string | `""` | Override the name of the chart. |
 | nodeSelector | object | `{}` | [Kubernetes node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for the webhook. |
 | podDisruptionBudget | object | `{"enabled":false}` | [Kubernetes pod disruption budget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) |
-| podSecurityContext | object | `{}` | [Kubernetes pod security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) for the webhook. |
+| podSecurityContext | object | [Restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted) | [Kubernetes pod security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) for the webhook. |
 | replicaCount | int | `1` | Number of replicas. |
 | resources | object | `{}` | [Kubernetes resource management](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the webhook |
 | service.port | int | `443` | Port of the webhook service. |

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -76,7 +76,7 @@ spec:
               mountPath: /tls
               readOnly: true
           {{- with .Values.containerSecurityContext }}
-          securityContext: {{- toYaml . | nindent 12 }}
+          securityContext: {{- toYamlPretty . | nindent 12 }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -73,10 +73,19 @@ tolerations: []
 affinity: {}
 
 # -- [Kubernetes pod security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) for the webhook.
-podSecurityContext: {}
+# @default -- [Restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted)
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
 
 # -- [Kubernetes container security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) for the webhook.
-containerSecurityContext: {}
+# @default -- [Restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted)
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
 
 # -- [Kubernetes deployment strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) for the deployment.
 strategy:


### PR DESCRIPTION
The webhook does not need any specific priviledges to work correctly. For this reason we can configure the security context to the Pod security standard [restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted).