### PR TITLE
fix(helm): allow configuring pod labels and annotations

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -22,7 +22,9 @@ cert-manager ACME webhook for Hetzner
 | metrics.serviceMonitor.enabled | bool | `false` | Deploys a ServiceMonitor to scrape the metrics. **Requires** the ServiceMonitor CRD. |
 | nameOverride | string | `""` | Override the name of the chart. |
 | nodeSelector | object | `{}` | [Kubernetes node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) for the webhook. |
+| podAnnotations | object | `{}` | [Kubernetes annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) added to the pod metadata |
 | podDisruptionBudget | object | `{"enabled":false}` | [Kubernetes pod disruption budget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) |
+| podLabels | object | `{}` | [Kubernetes labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) added to the pod metadata |
 | podSecurityContext | object | [Restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted) | [Kubernetes pod security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod) for the webhook. |
 | replicaCount | int | `1` | Number of replicas. |
 | resources | object | `{}` | [Kubernetes resource management](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) for the webhook |

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -31,6 +31,13 @@ spec:
       labels:
         app: {{ include "cert-manager-webhook-hetzner.name" . }}
         release: {{ .Release.Name }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets: {{- toYaml . | nindent 8 }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -97,6 +97,12 @@ labels: {}
 # -- [Kubernetes annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) added to the deployment metadata
 annotations: {}
 
+# -- [Kubernetes labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) added to the pod metadata
+podLabels: {}
+
+# -- [Kubernetes annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) added to the pod metadata
+podAnnotations: {}
+
 # -- [Kubernetes pod disruption budget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)
 podDisruptionBudget:
   enabled: false


### PR DESCRIPTION
I have decided to separate the pod labels/annotations from the deployment labels/annotations. However, it would not take too much effort to adjust this so that both get the same labels/annotations, which I am happy to do if that is the intended solution. 

Closes #67