### PR TITLE
fix: set API http client timeout to 15s

### DIFF
--- a/internal/hetzner/hclient.go
+++ b/internal/hetzner/hclient.go
@@ -3,6 +3,8 @@ package hetzner
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -48,6 +50,7 @@ func NewHClientBuilder(kubeClient kubernetes.Interface, registry prometheus.Regi
 			hcloud.WithToken(string(token)),
 			hcloud.WithInstrumentation(registry),
 			hcloud.WithApplication("cert-manager-webhook-hetzner", version.Version),
+			hcloud.WithHTTPClient(&http.Client{Timeout: 15 * time.Second}),
 		}
 		if config.HCloudEndpoint != "" {
 			clientOpts = append(clientOpts, hcloud.WithEndpoint(config.HCloudEndpoint))


### PR DESCRIPTION
Do not hang indefinitely if the API is not reachable.

Client timeout error will be retried 5 times, with exponential backoff and jitter. 

Improve the error handling problem described in https://github.com/hetzner/cert-manager-webhook-hetzner/issues/73 by timing out if the outside world is not reachable.