### PR TITLE
refactor: prefer zoneutil.FormatTXTRecord over fmt.Sprintf

### DIFF
--- a/internal/hetzner/solver.go
+++ b/internal/hetzner/solver.go
@@ -154,7 +154,7 @@ func (c *Solver) CleanUp(ch *v1alpha1.ChallengeRequest) error {
 	action, _, err := hClient.Zone.RemoveRRSetRecords(ctx,
 		zoneRRSet,
 		hcloud.ZoneRRSetRemoveRecordsOpts{
-			Records: []hcloud.ZoneRRSetRecord{{Value: fmt.Sprintf("%q", ch.Key)}},
+			Records: []hcloud.ZoneRRSetRecord{{Value: zoneutil.FormatTXTRecord(ch.Key)}},
 		},
 	)
 	if err != nil {

--- a/internal/hetzner/solver_test.go
+++ b/internal/hetzner/solver_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/exp/kit/randutil"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/exp/mockutil"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud/exp/zoneutil"
 )
 
 func TestPresent(t *testing.T) {
@@ -60,7 +61,7 @@ func TestPresent(t *testing.T) {
 						body, err := io.ReadAll(r.Body)
 						require.NoError(t, err)
 						assert.JSONEq(t,
-							fmt.Sprintf(`{"records": [{ "value": %q }], "ttl": 300}`, fmt.Sprintf("%q", key)),
+							fmt.Sprintf(`{"records": [{ "value": %q }], "ttl": 300}`, zoneutil.FormatTXTRecord(key)),
 							string(body),
 						)
 					},
@@ -127,7 +128,7 @@ func TestCleanup(t *testing.T) {
 						body, err := io.ReadAll(r.Body)
 						require.NoError(t, err)
 						assert.JSONEq(t,
-							fmt.Sprintf(`{"records": [{ "value": %q }]}`, fmt.Sprintf("%q", key)),
+							fmt.Sprintf(`{"records": [{ "value": %q }]}`, zoneutil.FormatTXTRecord(key)),
 							string(body),
 						)
 					},


### PR DESCRIPTION
This was already partially implemented in #42 but I missed a few spots.