### PR TITLE
feat(helm): configurable extra volume mounts

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -12,6 +12,8 @@ cert-manager ACME webhook for Hetzner
 | certManager.serviceAccountName | string | `"cert-manager"` | Name of the cert-managers service account. |
 | containerSecurityContext | object | [Restricted](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted) | [Kubernetes container security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) for the webhook. |
 | env | object | `{}` | Additional environment variables, where each key represents the name of the variable. The value follows standard Kubernetes environment variable formats. |
+| extraVolumeMounts | list | `[]` | Additional volume mounts to add to the container. |
+| extraVolumes | list | `[]` | Additional [volumes](https://kubernetes.io/docs/concepts/storage/volumes/) to add to the pod. |
 | fullnameOverride | string | `""` | Override the full name of the chart. |
 | groupName | string | `"acme.hetzner.com"` | The GroupName here is used to identify your company or business unit that created this webhook. For example, this may be "acme.mycompany.com". This name will need to be referenced in each Issuer's `webhook` stanza to inform cert-manager of where to send ChallengePayload resources in order to solve the DNS01 challenge. This group name should be **unique**, hence using your own company's domain here is recommended. |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy of the webhook image. |

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -82,6 +82,9 @@ spec:
             - name: certs
               mountPath: /tls
               readOnly: true
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.containerSecurityContext }}
           securityContext: {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -91,6 +94,9 @@ spec:
         - name: certs
           secret:
             secretName: {{ include "cert-manager-webhook-hetzner.servingCertificate" . }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{ toYaml . | nindent 8 }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -97,6 +97,12 @@ labels: {}
 # -- [Kubernetes annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) added to the deployment metadata
 annotations: {}
 
+# -- Additional [volumes](https://kubernetes.io/docs/concepts/storage/volumes/) to add to the pod.
+extraVolumes: []
+
+# -- Additional volume mounts to add to the container.
+extraVolumeMounts: []
+
 # -- [Kubernetes labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) added to the pod metadata
 podLabels: {}
 


### PR DESCRIPTION
Allowing the user to mount additional volumes into the deployment is useful when using the Secrets Store CSI Driver as it still requires the "SecretProviderClass" to be mounted into a pod before it exposes the data as a normal kubernetes secret.

See: https://secrets-store-csi-driver.sigs.k8s.io/topics/sync-as-kubernetes-secret

