### PR TITLE
feat: configure hetzner token from file path

### DIFF
--- a/docs/reference/issuer-configuration.md
+++ b/docs/reference/issuer-configuration.md
@@ -28,19 +28,36 @@ The webhook is responsible for one or more issuers, each with its own configurat
     </tr>
     <tr>
         <td><code>config.tokenSecretKeyRef.name</code></td>
-        <td>string (<strong>Required</strong>)</td>
+        <td>string</td>
         <td></td>
-        <td>Name of the Kubernetes secret, which stores the Hetzner Cloud API token.</td>
+        <td>
+            Name of the Kubernetes secret, which stores the Hetzner Cloud API token.
+            Required unless <code>config.tokenFilePath</code> is set.
+        </td>
     </tr>
     <tr>
         <td><code>config.tokenSecretKeyRef.key</code></td>
-        <td>string (<strong>Required</strong>)</td>
+        <td>string</td>
         <td></td>
-        <td>Key in the Kubernetes secret, which stores the Hetzner Cloud API token.</td>
+        <td>
+            Key in the Kubernetes secret, which stores the Hetzner Cloud API token.
+            Required unless <code>config.tokenFilePath</code> is set.
+        </td>
+    </tr>
+    <tr>
+        <td><code>config.tokenFilePath</code></td>
+        <td>string</td>
+        <td></td>
+        <td>
+            Path to a file containing the Hetzner Cloud API token, mounted into
+            the webhook pod. Alternative to <code>config.tokenSecretKeyRef</code>;
+            if both are set, <code>tokenSecretKeyRef</code> takes precedence.
+            Trailing whitespace in the file is trimmed.
+        </td>
     </tr>
 </table>
 
-### Example
+### Example: token from Kubernetes secret
 
 ```yaml
 # issuer.yaml
@@ -54,4 +71,22 @@ solvers:
           tokenSecretKeyRef:
             name: hetzner
             key: token
+```
+
+### Example: token from mounted file
+
+Mount the token into the webhook pod (for example via the chart's
+`extraVolumes` / `extraVolumeMounts` values, a projected volume, or a CSI
+secret driver) and reference its path in the issuer config:
+
+```yaml
+# issuer.yaml
+# [...]
+solvers:
+  - dns01:
+      webhook:
+        groupName: acme.hetzner.com
+        solverName: hetzner
+        config:
+          tokenFilePath: /var/run/secrets/hetzner/token
 ```

--- a/docs/reference/issuer-configuration.md
+++ b/docs/reference/issuer-configuration.md
@@ -52,7 +52,7 @@ The webhook is responsible for one or more issuers, each with its own configurat
             Path to a file containing the Hetzner Cloud API token, mounted into
             the webhook pod. Mutually exclusive with <code>config.tokenSecretKeyRef</code>;
             setting both is an error. Leading and trailing whitespace in the file
-            is trimmed.
+            are trimmed.
         </td>
     </tr>
 </table>

--- a/docs/reference/issuer-configuration.md
+++ b/docs/reference/issuer-configuration.md
@@ -41,7 +41,8 @@ The webhook is responsible for one or more issuers, each with its own configurat
         <td></td>
         <td>
             Key in the Kubernetes secret, which stores the Hetzner Cloud API token.
-            Required unless <code>config.tokenFilePath</code> is set.
+            Required unless <code>config.tokenFilePath</code> is set. Leading and
+            trailing whitespace in the token are trimmed.
         </td>
     </tr>
     <tr>

--- a/docs/reference/issuer-configuration.md
+++ b/docs/reference/issuer-configuration.md
@@ -50,9 +50,9 @@ The webhook is responsible for one or more issuers, each with its own configurat
         <td></td>
         <td>
             Path to a file containing the Hetzner Cloud API token, mounted into
-            the webhook pod. Alternative to <code>config.tokenSecretKeyRef</code>;
-            if both are set, <code>tokenSecretKeyRef</code> takes precedence.
-            Trailing whitespace in the file is trimmed.
+            the webhook pod. Mutually exclusive with <code>config.tokenSecretKeyRef</code>;
+            setting both is an error. Leading and trailing whitespace in the file
+            is trimmed.
         </td>
     </tr>
 </table>

--- a/internal/hetzner/config.go
+++ b/internal/hetzner/config.go
@@ -13,8 +13,9 @@ import (
 // issuer. This typically includes references to Secret resources containing DNS
 // provider credentials, in cases where a 'multi-tenant' DNS solver is being created.
 type Config struct {
-	HetznerTokenSecret SecretKeyRef `json:"tokenSecretKeyRef"`
-	HCloudEndpoint     string       `json:"hcloudEndpoint"`
+	HetznerTokenSecret   SecretKeyRef `json:"tokenSecretKeyRef"`
+	HetznerTokenFilePath string       `json:"tokenFilePath"`
+	HCloudEndpoint       string       `json:"hcloudEndpoint"`
 }
 
 type SecretKeyRef struct {

--- a/internal/hetzner/config_test.go
+++ b/internal/hetzner/config_test.go
@@ -20,6 +20,7 @@ func TestLoadConfig(t *testing.T) {
 			name: "valid",
 			raw: `{
 				"hcloudEndpoint": "https://changed.com/v2",
+				"tokenFilePath": "/tmp/hetzner",
 				"tokenSecretKeyRef": {
 					"name": "hetzner",
 					"key": "token"
@@ -30,7 +31,8 @@ func TestLoadConfig(t *testing.T) {
 					Name: "hetzner",
 					Key:  "token",
 				},
-				HCloudEndpoint: "https://changed.com/v2",
+				HetznerTokenFilePath: "/tmp/hetzner",
+				HCloudEndpoint:       "https://changed.com/v2",
 			},
 		},
 		{

--- a/internal/hetzner/hclient.go
+++ b/internal/hetzner/hclient.go
@@ -1,9 +1,11 @@
 package hetzner
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -27,23 +29,39 @@ func NewHClientBuilder(kubeClient kubernetes.Interface, registry prometheus.Regi
 		namespace string,
 		config Config,
 	) (*hcloud.Client, error) {
-		secret, err := kubeClient.CoreV1().Secrets(namespace).Get(
-			ctx,
-			config.HetznerTokenSecret.Name,
-			v1.GetOptions{},
-		)
-		if err != nil {
-			return nil, err
+		var token []byte
+
+		if config.HetznerTokenSecret.Name != "" {
+			secret, err := kubeClient.CoreV1().Secrets(namespace).Get(
+				ctx,
+				config.HetznerTokenSecret.Name,
+				v1.GetOptions{},
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			var ok bool
+			token, ok = secret.Data[config.HetznerTokenSecret.Key]
+			if !ok {
+				return nil, fmt.Errorf(
+					"secret %s in namespace %s does not contain key %s",
+					config.HetznerTokenSecret.Name,
+					namespace,
+					config.HetznerTokenSecret.Key,
+				)
+			}
+		} else if config.HetznerTokenFilePath != "" {
+			data, err := os.ReadFile(config.HetznerTokenFilePath)
+			if err != nil {
+				return nil, fmt.Errorf("error reading hetzner token file: %w", err)
+			}
+			token = data
 		}
 
-		token, ok := secret.Data[config.HetznerTokenSecret.Key]
-		if !ok {
-			return nil, fmt.Errorf(
-				"secret %s in namespace %s does not contain key %s",
-				config.HetznerTokenSecret.Name,
-				namespace,
-				config.HetznerTokenSecret.Key,
-			)
+		token = bytes.TrimSpace(token)
+		if len(token) == 0 {
+			return nil, fmt.Errorf("hetzner token not provided (set tokenSecretKeyRef or tokenFilePath)")
 		}
 
 		clientOpts := []hcloud.ClientOption{

--- a/internal/hetzner/hclient.go
+++ b/internal/hetzner/hclient.go
@@ -39,7 +39,7 @@ func NewHClientBuilder(kubeClient kubernetes.Interface, registry prometheus.Regi
 
 		switch {
 		case secretConfigured && fileConfigured:
-			return nil, errors.New("hetzner token is ambiguous: set either tokenSecretKeyRef or tokenFilePath, not both")
+			return nil, errors.New("hetzner token provided in both tokenSecretKeyRef and tokenFilePath")
 		case secretConfigured:
 			token, err = loadTokenFromSecret(ctx, kubeClient, namespace, config.HetznerTokenSecret)
 		case fileConfigured:

--- a/internal/hetzner/hclient.go
+++ b/internal/hetzner/hclient.go
@@ -3,6 +3,7 @@ package hetzner
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -29,39 +30,30 @@ func NewHClientBuilder(kubeClient kubernetes.Interface, registry prometheus.Regi
 		namespace string,
 		config Config,
 	) (*hcloud.Client, error) {
-		var token []byte
+		var (
+			token []byte
+			err   error
+		)
+		secretConfigured := config.HetznerTokenSecret.Name != ""
+		fileConfigured := config.HetznerTokenFilePath != ""
 
-		if config.HetznerTokenSecret.Name != "" {
-			secret, err := kubeClient.CoreV1().Secrets(namespace).Get(
-				ctx,
-				config.HetznerTokenSecret.Name,
-				v1.GetOptions{},
-			)
-			if err != nil {
-				return nil, err
-			}
-
-			var ok bool
-			token, ok = secret.Data[config.HetznerTokenSecret.Key]
-			if !ok {
-				return nil, fmt.Errorf(
-					"secret %s in namespace %s does not contain key %s",
-					config.HetznerTokenSecret.Name,
-					namespace,
-					config.HetznerTokenSecret.Key,
-				)
-			}
-		} else if config.HetznerTokenFilePath != "" {
-			data, err := os.ReadFile(config.HetznerTokenFilePath)
-			if err != nil {
-				return nil, fmt.Errorf("error reading hetzner token file: %w", err)
-			}
-			token = data
+		switch {
+		case secretConfigured && fileConfigured:
+			return nil, errors.New("hetzner token is ambiguous: set either tokenSecretKeyRef or tokenFilePath, not both")
+		case secretConfigured:
+			token, err = loadTokenFromSecret(ctx, kubeClient, namespace, config.HetznerTokenSecret)
+		case fileConfigured:
+			token, err = loadTokenFromFile(config.HetznerTokenFilePath)
+		default:
+			return nil, errors.New("hetzner token not provided (set tokenSecretKeyRef or tokenFilePath)")
+		}
+		if err != nil {
+			return nil, err
 		}
 
 		token = bytes.TrimSpace(token)
 		if len(token) == 0 {
-			return nil, fmt.Errorf("hetzner token not provided (set tokenSecretKeyRef or tokenFilePath)")
+			return nil, errors.New("hetzner token is empty")
 		}
 
 		clientOpts := []hcloud.ClientOption{
@@ -76,6 +68,35 @@ func NewHClientBuilder(kubeClient kubernetes.Interface, registry prometheus.Regi
 
 		return hcloud.NewClient(clientOpts...), nil
 	}
+}
+
+func loadTokenFromSecret(
+	ctx context.Context,
+	kubeClient kubernetes.Interface,
+	namespace string,
+	ref SecretKeyRef,
+) ([]byte, error) {
+	secret, err := kubeClient.CoreV1().Secrets(namespace).Get(ctx, ref.Name, v1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	token, ok := secret.Data[ref.Key]
+	if !ok {
+		return nil, fmt.Errorf(
+			"secret %s in namespace %s does not contain key %s",
+			ref.Name, namespace, ref.Key,
+		)
+	}
+	return token, nil
+}
+
+func loadTokenFromFile(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("error reading hetzner token file: %w", err)
+	}
+	return data, nil
 }
 
 func MockHClientBuilder(client *hcloud.Client) HClientBuilderFunc {

--- a/internal/hetzner/hclient_test.go
+++ b/internal/hetzner/hclient_test.go
@@ -2,6 +2,9 @@ package hetzner
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -25,7 +28,7 @@ func TestBuildClient(t *testing.T) {
 				Namespace: namespace,
 			},
 			Data: map[string][]byte{
-				"token": {},
+				"token": []byte("test-token"),
 			},
 		}
 
@@ -52,5 +55,49 @@ hcloud_api_requests_total{api_endpoint="/locations",code="401",method="get"} 1
 `),
 			"hcloud_api_requests_total",
 		))
+	})
+
+	t.Run("TokenFromFile", func(t *testing.T) {
+		tokenPath := filepath.Join(t.TempDir(), "token")
+		require.NoError(t, os.WriteFile(tokenPath, []byte("file-token\n"), 0o600))
+
+		config := Config{
+			HetznerTokenFilePath: tokenPath,
+		}
+
+		builder := NewHClientBuilder(fake.NewClientset(), prometheus.NewRegistry())
+		client, err := builder(t.Context(), "default", config)
+		require.NoError(t, err)
+		require.NotNil(t, client)
+	})
+
+	t.Run("TokenFileMissing", func(t *testing.T) {
+		tokenPath := filepath.Join(t.TempDir(), "does-not-exist")
+		config := Config{
+			HetznerTokenFilePath: tokenPath,
+		}
+
+		builder := NewHClientBuilder(fake.NewClientset(), prometheus.NewRegistry())
+		_, err := builder(t.Context(), "default", config)
+		require.EqualError(t, err, fmt.Sprintf("error reading hetzner token file: open %s: no such file or directory", tokenPath))
+	})
+
+	t.Run("TokenFileEmpty", func(t *testing.T) {
+		tokenPath := filepath.Join(t.TempDir(), "token")
+		require.NoError(t, os.WriteFile(tokenPath, []byte("   \n"), 0o600))
+
+		config := Config{
+			HetznerTokenFilePath: tokenPath,
+		}
+
+		builder := NewHClientBuilder(fake.NewClientset(), prometheus.NewRegistry())
+		_, err := builder(t.Context(), "default", config)
+		require.EqualError(t, err, "hetzner token not provided (set tokenSecretKeyRef or tokenFilePath)")
+	})
+
+	t.Run("NoTokenConfigured", func(t *testing.T) {
+		builder := NewHClientBuilder(fake.NewClientset(), prometheus.NewRegistry())
+		_, err := builder(t.Context(), "default", Config{})
+		require.EqualError(t, err, "hetzner token not provided (set tokenSecretKeyRef or tokenFilePath)")
 	})
 }

--- a/internal/hetzner/hclient_test.go
+++ b/internal/hetzner/hclient_test.go
@@ -2,7 +2,7 @@ package hetzner
 
 import (
 	"context"
-	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -79,7 +79,8 @@ hcloud_api_requests_total{api_endpoint="/locations",code="401",method="get"} 1
 
 		builder := NewHClientBuilder(fake.NewClientset(), prometheus.NewRegistry())
 		_, err := builder(t.Context(), "default", config)
-		require.EqualError(t, err, fmt.Sprintf("error reading hetzner token file: open %s: no such file or directory", tokenPath))
+		require.ErrorContains(t, err, "error reading hetzner token file")
+		require.ErrorIs(t, err, fs.ErrNotExist)
 	})
 
 	t.Run("TokenFileEmpty", func(t *testing.T) {
@@ -92,12 +93,23 @@ hcloud_api_requests_total{api_endpoint="/locations",code="401",method="get"} 1
 
 		builder := NewHClientBuilder(fake.NewClientset(), prometheus.NewRegistry())
 		_, err := builder(t.Context(), "default", config)
-		require.EqualError(t, err, "hetzner token not provided (set tokenSecretKeyRef or tokenFilePath)")
+		require.EqualError(t, err, "hetzner token is empty")
 	})
 
 	t.Run("NoTokenConfigured", func(t *testing.T) {
 		builder := NewHClientBuilder(fake.NewClientset(), prometheus.NewRegistry())
 		_, err := builder(t.Context(), "default", Config{})
 		require.EqualError(t, err, "hetzner token not provided (set tokenSecretKeyRef or tokenFilePath)")
+	})
+
+	t.Run("BothTokenSourcesConfigured", func(t *testing.T) {
+		config := Config{
+			HetznerTokenSecret:   SecretKeyRef{Name: "hcloud", Key: "token"},
+			HetznerTokenFilePath: "/tmp/hetzner",
+		}
+
+		builder := NewHClientBuilder(fake.NewClientset(), prometheus.NewRegistry())
+		_, err := builder(t.Context(), "default", config)
+		require.EqualError(t, err, "hetzner token is ambiguous: set either tokenSecretKeyRef or tokenFilePath, not both")
 	})
 }

--- a/internal/hetzner/hclient_test.go
+++ b/internal/hetzner/hclient_test.go
@@ -137,6 +137,6 @@ hcloud_api_requests_total{api_endpoint="/locations",code="401",method="get"} 1
 
 		builder := NewHClientBuilder(fake.NewClientset(), prometheus.NewRegistry())
 		_, err := builder(t.Context(), "default", config)
-		require.EqualError(t, err, "hetzner token is ambiguous: set either tokenSecretKeyRef or tokenFilePath, not both")
+		require.EqualError(t, err, "hetzner token provided in both tokenSecretKeyRef and tokenFilePath")
 	})
 }

--- a/internal/hetzner/hclient_test.go
+++ b/internal/hetzner/hclient_test.go
@@ -57,6 +57,33 @@ hcloud_api_requests_total{api_endpoint="/locations",code="401",method="get"} 1
 		))
 	})
 
+	t.Run("SecretMissingKey", func(t *testing.T) {
+		namespace := "default"
+
+		secret := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "hcloud",
+				Namespace: namespace,
+			},
+			Data: map[string][]byte{
+				"other-key": []byte("test-token"),
+			},
+		}
+
+		kubeClientSet := fake.NewClientset(secret)
+
+		config := Config{
+			HetznerTokenSecret: SecretKeyRef{
+				Name: "hcloud",
+				Key:  "token",
+			},
+		}
+
+		builder := NewHClientBuilder(kubeClientSet, prometheus.NewRegistry())
+		_, err := builder(t.Context(), namespace, config)
+		require.EqualError(t, err, "secret hcloud in namespace default does not contain key token")
+	})
+
 	t.Run("TokenFromFile", func(t *testing.T) {
 		tokenPath := filepath.Join(t.TempDir(), "token")
 		require.NoError(t, os.WriteFile(tokenPath, []byte("file-token\n"), 0o600))


### PR DESCRIPTION
Allows users to configure an alternative to the Kubernetes secret backend.

Fixes #153