### PR TITLE
feat(hetzner): make Hetzner Cloud API HTTP timeout configurable

### DIFF
--- a/docs/reference/issuer-configuration.md
+++ b/docs/reference/issuer-configuration.md
@@ -56,6 +56,18 @@ The webhook is responsible for one or more issuers, each with its own configurat
             are trimmed.
         </td>
     </tr>
+    <tr>
+        <td><code>config.httpTimeout</code></td>
+        <td>string</td>
+        <td><code>15s</code></td>
+        <td>
+            Per-request timeout for calls to the Hetzner Cloud API, as a
+            <a href="https://pkg.go.dev/time#ParseDuration">Go duration string</a>
+            (e.g. <code>45s</code>, <code>1m</code>). Increase this if DNS record
+            creation/deletion intermittently fails with a timeout error, e.g. because
+            the Zones API is slower to respond than usual in your environment.
+        </td>
+    </tr>
 </table>
 
 ### Example: token from Kubernetes secret

--- a/internal/hetzner/config.go
+++ b/internal/hetzner/config.go
@@ -16,6 +16,11 @@ type Config struct {
 	HetznerTokenSecret   SecretKeyRef `json:"tokenSecretKeyRef"`
 	HetznerTokenFilePath string       `json:"tokenFilePath"`
 	HCloudEndpoint       string       `json:"hcloudEndpoint"`
+
+	// HTTPTimeout overrides the default per-request timeout used for calls to the
+	// Hetzner Cloud API, e.g. "45s". Must be a positive duration parseable by
+	// [time.ParseDuration]. Falls back to [DefaultHTTPTimeout] when empty.
+	HTTPTimeout string `json:"httpTimeout"`
 }
 
 type SecretKeyRef struct {

--- a/internal/hetzner/config_test.go
+++ b/internal/hetzner/config_test.go
@@ -24,7 +24,8 @@ func TestLoadConfig(t *testing.T) {
 				"tokenSecretKeyRef": {
 					"name": "hetzner",
 					"key": "token"
-				}
+				},
+				"httpTimeout": "45s"
 			}`,
 			want: Config{
 				HetznerTokenSecret: SecretKeyRef{
@@ -33,6 +34,7 @@ func TestLoadConfig(t *testing.T) {
 				},
 				HetznerTokenFilePath: "/tmp/hetzner",
 				HCloudEndpoint:       "https://changed.com/v2",
+				HTTPTimeout:          "45s",
 			},
 		},
 		{

--- a/internal/hetzner/hclient.go
+++ b/internal/hetzner/hclient.go
@@ -17,6 +17,30 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
+// DefaultHTTPTimeout is the per-request timeout used when [Config.HTTPTimeout] is not
+// set. Kept short enough that the SDK's built-in retry loop (5 retries, exponential
+// backoff) stays comfortably bounded, so a genuinely unreachable API still fails with a
+// clear timeout error instead of running into an outer deadline first.
+const DefaultHTTPTimeout = 15 * time.Second
+
+// resolveHTTPTimeout parses [Config.HTTPTimeout], falling back to [DefaultHTTPTimeout]
+// when it is empty. A zero or negative duration is rejected, since [http.Client]
+// treats that as "no timeout" rather than "immediate timeout".
+func resolveHTTPTimeout(raw string) (time.Duration, error) {
+	if raw == "" {
+		return DefaultHTTPTimeout, nil
+	}
+
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("error parsing httpTimeout: %w", err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("httpTimeout must be positive, got %s", d)
+	}
+	return d, nil
+}
+
 // HClientBuilderFunc is a function that builds a [hcloud.Client] from a secret stored in kubernetes.
 type HClientBuilderFunc func(
 	ctx context.Context,
@@ -56,11 +80,16 @@ func NewHClientBuilder(kubeClient kubernetes.Interface, registry prometheus.Regi
 			return nil, errors.New("hetzner token is empty")
 		}
 
+		httpTimeout, err := resolveHTTPTimeout(config.HTTPTimeout)
+		if err != nil {
+			return nil, err
+		}
+
 		clientOpts := []hcloud.ClientOption{
 			hcloud.WithToken(string(token)),
 			hcloud.WithInstrumentation(registry),
 			hcloud.WithApplication("cert-manager-webhook-hetzner", version.Version),
-			hcloud.WithHTTPClient(&http.Client{Timeout: 15 * time.Second}),
+			hcloud.WithHTTPClient(&http.Client{Timeout: httpTimeout}),
 		}
 		if config.HCloudEndpoint != "" {
 			clientOpts = append(clientOpts, hcloud.WithEndpoint(config.HCloudEndpoint))

--- a/internal/hetzner/hclient_test.go
+++ b/internal/hetzner/hclient_test.go
@@ -3,13 +3,17 @@ package hetzner
 import (
 	"context"
 	"io/fs"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -138,5 +142,84 @@ hcloud_api_requests_total{api_endpoint="/locations",code="401",method="get"} 1
 		builder := NewHClientBuilder(fake.NewClientset(), prometheus.NewRegistry())
 		_, err := builder(t.Context(), "default", config)
 		require.EqualError(t, err, "hetzner token provided in both tokenSecretKeyRef and tokenFilePath")
+	})
+
+	t.Run("InvalidHTTPTimeout", func(t *testing.T) {
+		config := Config{
+			HetznerTokenFilePath: writeTestToken(t),
+			HTTPTimeout:          "not-a-duration",
+		}
+
+		builder := NewHClientBuilder(fake.NewClientset(), prometheus.NewRegistry())
+		_, err := builder(t.Context(), "default", config)
+		require.ErrorContains(t, err, "error parsing httpTimeout")
+	})
+
+	t.Run("CustomHTTPTimeoutIsAppliedToClient", func(t *testing.T) {
+		// A server that responds slower than the configured timeout allows. The call
+		// context is bounded well below the SDK's first retry backoff (1s), so a
+		// correctly-applied short timeout fails fast within that bound; if the
+		// configured value were ignored in favor of the (much larger) default, the
+		// request would still be in flight when the context deadline cuts it off with
+		// a different error instead.
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			time.Sleep(50 * time.Millisecond)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		}))
+		t.Cleanup(server.Close)
+
+		config := Config{
+			HetznerTokenFilePath: writeTestToken(t),
+			HCloudEndpoint:       server.URL,
+			HTTPTimeout:          "10ms",
+		}
+
+		builder := NewHClientBuilder(fake.NewClientset(), prometheus.NewRegistry())
+		client, err := builder(t.Context(), "default", config)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+		defer cancel()
+
+		_, err = client.Location.All(ctx)
+		require.ErrorContains(t, err, "Client.Timeout")
+	})
+}
+
+func writeTestToken(t *testing.T) string {
+	t.Helper()
+
+	tokenPath := filepath.Join(t.TempDir(), "token")
+	require.NoError(t, os.WriteFile(tokenPath, []byte("test-token"), 0o600))
+	return tokenPath
+}
+
+func TestResolveHTTPTimeout(t *testing.T) {
+	t.Run("Empty falls back to default", func(t *testing.T) {
+		d, err := resolveHTTPTimeout("")
+		require.NoError(t, err)
+		assert.Equal(t, DefaultHTTPTimeout, d)
+	})
+
+	t.Run("Valid duration is parsed", func(t *testing.T) {
+		d, err := resolveHTTPTimeout("45s")
+		require.NoError(t, err)
+		assert.Equal(t, 45*time.Second, d)
+	})
+
+	t.Run("Invalid duration returns an error", func(t *testing.T) {
+		_, err := resolveHTTPTimeout("not-a-duration")
+		require.ErrorContains(t, err, "error parsing httpTimeout")
+	})
+
+	t.Run("Zero duration is rejected", func(t *testing.T) {
+		_, err := resolveHTTPTimeout("0s")
+		require.ErrorContains(t, err, "httpTimeout must be positive")
+	})
+
+	t.Run("Negative duration is rejected", func(t *testing.T) {
+		_, err := resolveHTTPTimeout("-5s")
+		require.ErrorContains(t, err, "httpTimeout must be positive")
 	})
 }


### PR DESCRIPTION
#91 set the per-request HTTP client timeout to a hardcoded 15s so that a blocked/unreachable API (#73) fails fast instead of hanging, relying on the SDK's own retry loop (5 retries, exponential backoff) to keep overall latency bounded.

That same fixed value can also be too short for a slow-but-reachable Hetzner Cloud Zones API response, causing DNS-01 record creation or cleanup to intermittently fail with the same timeout error after exhausting all retries, even though the API is healthy.

Add an optional httpTimeout field to the Issuer solver config (a Go duration string, e.g. "45s") so this can be tuned per-environment without a custom image. The 15s default is unchanged, since raising it would also raise the worst-case duration of the retry loop #91 relies on to stay under whatever imposes the outer deadline in the truly-unreachable case.